### PR TITLE
Fixing incorrect assert comment

### DIFF
--- a/src/main/java/me/sudohippie/throttle/strategy/bucket/LeakyTokenBucketStrategy.java
+++ b/src/main/java/me/sudohippie/throttle/strategy/bucket/LeakyTokenBucketStrategy.java
@@ -24,7 +24,7 @@ public abstract class LeakyTokenBucketStrategy extends TokenBucketStrategy {
         super(maxTokens, refillInterval, refillIntervalTimeUnit);
 
         // preconditions
-        Assert.isTrue(stepInterval >= 0, "Step interval is not negative");
+        Assert.isTrue(stepInterval >= 0, "Step interval can not be negative");
         Assert.isTrue(stepTokens >= 0, "Step token can not be negative");
 
         this.stepTokens = stepTokens;


### PR DESCRIPTION
The comment on the assert statement is incorrect. It's clearly requiring the value to be positive, which contradicts the message "Step interval is not negative"
